### PR TITLE
fix(release): use file-based asset paths instead of GITHUB_ENV

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,7 +249,7 @@ jobs:
         run: |
           ARCHIVE_NAME=$(cat archive_name.txt)
           tar czf "${ARCHIVE_NAME}.tar.gz" "${ARCHIVE_NAME}"
-          echo "ASSET_PATH=${ARCHIVE_NAME}.tar.gz" >> $GITHUB_ENV
+          echo "${ARCHIVE_NAME}.tar.gz" > asset_path.txt
         shell: bash
 
       - name: Create archive (Windows)
@@ -257,37 +257,42 @@ jobs:
         run: |
           $ARCHIVE_NAME = Get-Content archive_name.txt
           Compress-Archive -Path "$ARCHIVE_NAME/*" -DestinationPath "$ARCHIVE_NAME.zip"
-          echo "ASSET_PATH=$ARCHIVE_NAME.zip" >> $env:GITHUB_ENV
+          "$ARCHIVE_NAME.zip" | Out-File -FilePath asset_path.txt -Encoding ASCII -NoNewline
 
       - name: Generate checksum (Linux)
         if: runner.os == 'Linux'
         run: |
-          sha256sum "${{ env.ASSET_PATH }}" > "${{ env.ASSET_PATH }}.sha256"
-          cat "${{ env.ASSET_PATH }}.sha256"
+          ASSET_PATH=$(cat asset_path.txt)
+          sha256sum "$ASSET_PATH" > "$ASSET_PATH.sha256"
+          cat "$ASSET_PATH.sha256"
         shell: bash
 
       - name: Generate checksum (macOS)
         if: runner.os == 'macOS'
         run: |
-          shasum -a 256 "${{ env.ASSET_PATH }}" > "${{ env.ASSET_PATH }}.sha256"
-          cat "${{ env.ASSET_PATH }}.sha256"
+          ASSET_PATH=$(cat asset_path.txt)
+          shasum -a 256 "$ASSET_PATH" > "$ASSET_PATH.sha256"
+          cat "$ASSET_PATH.sha256"
         shell: bash
 
       - name: Generate checksum (Windows)
         if: runner.os == 'Windows'
         run: |
-          $hash = (Get-FileHash "${{ env.ASSET_PATH }}" -Algorithm SHA256).Hash.ToLower()
-          $filename = Split-Path "${{ env.ASSET_PATH }}" -Leaf
-          "$hash  $filename" | Out-File -FilePath "${{ env.ASSET_PATH }}.sha256" -Encoding ASCII
-          Get-Content "${{ env.ASSET_PATH }}.sha256"
+          $ASSET_PATH = Get-Content asset_path.txt -Raw
+          $ASSET_PATH = $ASSET_PATH.Trim()
+          $hash = (Get-FileHash "$ASSET_PATH" -Algorithm SHA256).Hash.ToLower()
+          $filename = Split-Path "$ASSET_PATH" -Leaf
+          "$hash  $filename" | Out-File -FilePath "$ASSET_PATH.sha256" -Encoding ASCII
+          Get-Content "$ASSET_PATH.sha256"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: binary-${{ matrix.target }}
           path: |
-            ${{ env.ASSET_PATH }}
-            ${{ env.ASSET_PATH }}.sha256
+            *.tar.gz
+            *.zip
+            *.sha256
           retention-days: 1
 
   publish-release:


### PR DESCRIPTION
## Summary

Addresses P0 code review feedback from PR #5 about potential variable evaluation timing issues with `$GITHUB_ENV` in GitHub Actions.

## Changes

### Problem

The original workflow used `$GITHUB_ENV` to pass the asset path between steps, which could cause evaluation timing issues where the variable might not be available immediately in the next step.

### Solution

Replaced with file-based approach using `asset_path.txt`:

- Archive creation steps write the asset filename to `asset_path.txt`
- Checksum steps read from `asset_path.txt` into a shell variable
- Upload artifact step uses glob patterns instead of env variable

### Files Changed

- `.github/workflows/release.yml` - Updated all archive creation and checksum steps (Unix and Windows)

## Testing

This change maintains the same behavior but avoids potential timing issues. The workflow structure is unchanged.

## Review Context

- Original PR: #5
- Review priority: P0
- Reviewer: codex bot

## Checklist

- [x] Fix applied to all affected steps (Unix archive, Windows archive, all checksum steps)
- [x] Tested cherry-pick from original feature branch
- [ ] CI passes

Fixes: Code review feedback from PR #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
