### PR TITLE
chore(release): streamline homebrew formula updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -445,30 +445,42 @@ jobs:
 
       - name: Update formula
         run: |
-          VERSION="${{ needs.create-release.outputs.version }}"
-          cd homebrew-tap/Formula
+          export VERSION="${{ needs.create-release.outputs.version }}"
+          export MACOS_INTEL="${{ steps.checksums.outputs.macos_intel }}"
+          export MACOS_ARM="${{ steps.checksums.outputs.macos_arm }}"
+          export LINUX_INTEL="${{ steps.checksums.outputs.linux_intel }}"
+          export LINUX_ARM="${{ steps.checksums.outputs.linux_arm }}"
 
-          echo "Updating formula to version $VERSION..."
+          echo "Updating branchbox.rb to version $VERSION"
+          sed -i 's/^  version ".*"/  version "'$VERSION'"/' homebrew-tap/Formula/branchbox.rb
 
-          # Update macOS Intel URL and checksum
-          sed -i 's|url "https://github.com/branchbox/branchbox/releases/download/v.*/branchbox-.*-x86_64-apple-darwin.tar.gz"|url "https://github.com/branchbox/branchbox/releases/download/v'$VERSION'/branchbox-'$VERSION'-x86_64-apple-darwin.tar.gz"|' branchbox.rb
-          sed -i '0,/x86_64-apple-darwin/{//!b};N;s/sha256 "[^"]*"/sha256 "'${{ steps.checksums.outputs.macos_intel }}'"/' branchbox.rb
-
-          # Update macOS ARM URL and checksum
-          sed -i 's|url "https://github.com/branchbox/branchbox/releases/download/v.*/branchbox-.*-aarch64-apple-darwin.tar.gz"|url "https://github.com/branchbox/branchbox/releases/download/v'$VERSION'/branchbox-'$VERSION'-aarch64-apple-darwin.tar.gz"|' branchbox.rb
-          sed -i '0,/aarch64-apple-darwin/{//!b};N;s/sha256 "[^"]*"/sha256 "'${{ steps.checksums.outputs.macos_arm }}'"/' branchbox.rb
-
-          # Update Linux Intel URL and checksum
-          sed -i 's|url "https://github.com/branchbox/branchbox/releases/download/v.*/branchbox-.*-x86_64-unknown-linux-gnu.tar.gz"|url "https://github.com/branchbox/branchbox/releases/download/v'$VERSION'/branchbox-'$VERSION'-x86_64-unknown-linux-gnu.tar.gz"|' branchbox.rb
-          sed -i '0,/x86_64-unknown-linux-gnu/{//!b};N;s/sha256 "[^"]*"/sha256 "'${{ steps.checksums.outputs.linux_intel }}'"/' branchbox.rb
-
-          # Update Linux ARM URL and checksum
-          sed -i 's|url "https://github.com/branchbox/branchbox/releases/download/v.*/branchbox-.*-aarch64-unknown-linux-gnu.tar.gz"|url "https://github.com/branchbox/branchbox/releases/download/v'$VERSION'/branchbox-'$VERSION'-aarch64-unknown-linux-gnu.tar.gz"|' branchbox.rb
-          sed -i '0,/aarch64-unknown-linux-gnu/{//!b};N;s/sha256 "[^"]*"/sha256 "'${{ steps.checksums.outputs.linux_arm }}'"/' branchbox.rb
+          ruby <<'RUBY'
+            path = "homebrew-tap/Formula/branchbox.rb"
+            sha = {
+              "x86_64-apple-darwin"      => ENV.fetch("MACOS_INTEL"),
+              "aarch64-apple-darwin"     => ENV.fetch("MACOS_ARM"),
+              "x86_64-unknown-linux-gnu" => ENV.fetch("LINUX_INTEL"),
+              "aarch64-unknown-linux-gnu"=> ENV.fetch("LINUX_ARM"),
+            }
+            contents = File.read(path)
+            sha.each do |arch, checksum|
+              pattern = /(#{Regexp.escape(arch)}.*?\n\s*sha256 ")[0-9a-f]{64}"/
+              unless contents.sub!(pattern, "\\1#{checksum}\"")
+                abort "Failed to update checksum for #{arch} in #{path}"
+              end
+            end
+            File.write(path, contents)
+          RUBY
 
       - name: Verify formula updates
         run: |
           cd homebrew-tap/Formula
+          VERSION="${{ needs.create-release.outputs.version }}"
+
+          if ! grep -q "  version \"$VERSION\"" branchbox.rb; then
+            echo "❌ Error: Version line not updated to $VERSION"
+            exit 1
+          fi
 
           # Verify all checksums were updated
           for checksum in "${{ steps.checksums.outputs.macos_intel }}" \

--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -10,7 +10,7 @@ Automated Homebrew formula updates that run when stable releases are published.
 
 Runs after release jobs complete:
 - Downloads checksums from GitHub Release
-- Extracts macOS Intel + ARM checksums
+- Extracts macOS/Linux Intel + ARM checksums
 - Updates `Formula/branchbox.rb` with new version and SHA256s
 - Commits to [branchbox/homebrew-tap](https://github.com/branchbox/homebrew-tap)
 - Skips pre-releases automatically
@@ -46,12 +46,7 @@ Update Homebrew Formula
   └─ Commit & push
 ```
 
-Formula updates:
-```ruby
-version "0.2.0" → "0.2.1"
-sha256 "abc..." → "def..."  # Intel
-sha256 "xyz..." → "uvw..."  # ARM
-```
+Formula updates touch only the version line and four `sha256` entries; all URLs derive from `#{version}` inside platform-specific blocks.
 
 ---
 

--- a/docs/HOMEBREW_SETUP.md
+++ b/docs/HOMEBREW_SETUP.md
@@ -80,15 +80,32 @@ Formula structure changed. View [current formula](https://raw.githubusercontent.
 
 ```ruby
 class Branchbox < Formula
-  version "X.Y.Z"  # Must be this format
+  desc "Distributed development environment orchestrator"
+  homepage "https://github.com/branchbox/branchbox"
+  version "X.Y.Z"
+  license "MIT"
 
   on_macos do
-    if Hardware::CPU.intel?
-      url "https://github.com/branchbox/branchbox/releases/download/vX.Y.Z/branchbox-X.Y.Z-x86_64-apple-darwin.tar.gz"
-      sha256 "..."  # Must be on separate line
-    elsif Hardware::CPU.arm?
-      url "https://github.com/branchbox/branchbox/releases/download/vX.Y.Z/branchbox-X.Y.Z-aarch64-apple-darwin.tar.gz"
-      sha256 "..."  # Must be on separate line
+    on_intel do
+      url "https://github.com/branchbox/branchbox/releases/download/v#{version}/branchbox-#{version}-x86_64-apple-darwin.tar.gz"
+      sha256 "..."  # Replace with macOS Intel checksum
+    end
+
+    on_arm do
+      url "https://github.com/branchbox/branchbox/releases/download/v#{version}/branchbox-#{version}-aarch64-apple-darwin.tar.gz"
+      sha256 "..."  # Replace with macOS ARM checksum
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "https://github.com/branchbox/branchbox/releases/download/v#{version}/branchbox-#{version}-x86_64-unknown-linux-gnu.tar.gz"
+      sha256 "..."  # Replace with Linux Intel checksum
+    end
+
+    on_arm do
+      url "https://github.com/branchbox/branchbox/releases/download/v#{version}/branchbox-#{version}-aarch64-unknown-linux-gnu.tar.gz"
+      sha256 "..."  # Replace with Linux ARM checksum
     end
   end
 end

--- a/docs/features/completed/homebrew-tap-distribution.md
+++ b/docs/features/completed/homebrew-tap-distribution.md
@@ -74,12 +74,26 @@ class Branchbox < Formula
   license "MIT"
 
   on_macos do
-    if Hardware::CPU.intel?
-      url "https://github.com/branchbox/branchbox/releases/download/v0.2.0/branchbox-0.2.0-x86_64-apple-darwin.tar.gz"
-      sha256 "CHECKSUM_INTEL"
-    elsif Hardware::CPU.arm?
-      url "https://github.com/branchbox/branchbox/releases/download/v0.2.0/branchbox-0.2.0-aarch64-apple-darwin.tar.gz"
-      sha256 "CHECKSUM_ARM"
+    on_intel do
+      url "https://github.com/branchbox/branchbox/releases/download/v#{version}/branchbox-#{version}-x86_64-apple-darwin.tar.gz"
+      sha256 "CHECKSUM_MACOS_INTEL"
+    end
+
+    on_arm do
+      url "https://github.com/branchbox/branchbox/releases/download/v#{version}/branchbox-#{version}-aarch64-apple-darwin.tar.gz"
+      sha256 "CHECKSUM_MACOS_ARM"
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "https://github.com/branchbox/branchbox/releases/download/v#{version}/branchbox-#{version}-x86_64-unknown-linux-gnu.tar.gz"
+      sha256 "CHECKSUM_LINUX_INTEL"
+    end
+
+    on_arm do
+      url "https://github.com/branchbox/branchbox/releases/download/v#{version}/branchbox-#{version}-aarch64-unknown-linux-gnu.tar.gz"
+      sha256 "CHECKSUM_LINUX_ARM"
     end
   end
 
@@ -98,9 +112,11 @@ class Branchbox < Formula
 end
 ```
 
+> **Release team:** Land this refactor in `branchbox/homebrew-tap` before enabling automation. Ensure the formula adds `version "0.2.0"` immediately after `homepage`, uses `on_macos { on_intel / on_arm }` and `on_linux { on_intel / on_arm }`, and interpolates `#{version}` in every download URL so future bumps only touch the version and checksum lines.
+
 **Key features:**
-- Architecture detection using `Hardware::CPU.intel?` and `Hardware::CPU.arm?`
-- Separate download URLs for each architecture
+- Platform-specific blocks with `on_macos`/`on_linux` and `on_intel`/`on_arm`
+- Separate download URLs for each supported architecture
 - SHA256 verification for each binary
 - Version test to validate installation
 
@@ -130,27 +146,43 @@ update-homebrew:
     - name: Extract checksums
       id: checksums
       run: |
-        INTEL_CHECKSUM=$(grep "x86_64-apple-darwin" checksums.txt | awk '{print $1}')
-        ARM_CHECKSUM=$(grep "aarch64-apple-darwin" checksums.txt | awk '{print $1}')
+        MACOS_INTEL=$(grep "x86_64-apple-darwin" checksums.txt | awk '{print $1}')
+        MACOS_ARM=$(grep "aarch64-apple-darwin" checksums.txt | awk '{print $1}')
+        LINUX_INTEL=$(grep "x86_64-unknown-linux-gnu" checksums.txt | awk '{print $1}')
+        LINUX_ARM=$(grep "aarch64-unknown-linux-gnu" checksums.txt | awk '{print $1}')
 
-        echo "intel=$INTEL_CHECKSUM" >> $GITHUB_OUTPUT
-        echo "arm=$ARM_CHECKSUM" >> $GITHUB_OUTPUT
+        echo "macos_intel=$MACOS_INTEL" >> "$GITHUB_OUTPUT"
+        echo "macos_arm=$MACOS_ARM" >> "$GITHUB_OUTPUT"
+        echo "linux_intel=$LINUX_INTEL" >> "$GITHUB_OUTPUT"
+        echo "linux_arm=$LINUX_ARM" >> "$GITHUB_OUTPUT"
 
     - name: Update formula
       run: |
-        VERSION="${{ needs.create-release.outputs.version }}"
-        cd homebrew-tap/Formula
+        export VERSION="${{ needs.create-release.outputs.version }}"
+        export MACOS_INTEL="${{ steps.checksums.outputs.macos_intel }}"
+        export MACOS_ARM="${{ steps.checksums.outputs.macos_arm }}"
+        export LINUX_INTEL="${{ steps.checksums.outputs.linux_intel }}"
+        export LINUX_ARM="${{ steps.checksums.outputs.linux_arm }}"
 
-        # Update version
-        sed -i "s/version \".*\"/version \"$VERSION\"/" branchbox.rb
+        sed -i 's/^  version ".*"/  version "'$VERSION'"/' homebrew-tap/Formula/branchbox.rb
 
-        # Update Intel URL and checksum
-        sed -i "s|url \"https://github.com/branchbox/branchbox/releases/download/v.*/branchbox-.*-x86_64-apple-darwin.tar.gz\"|url \"https://github.com/branchbox/branchbox/releases/download/v$VERSION/branchbox-$VERSION-x86_64-apple-darwin.tar.gz\"|" branchbox.rb
-        sed -i "/Hardware::CPU.intel?/,/sha256/ s/sha256 \".*\"/sha256 \"${{ steps.checksums.outputs.intel }}\"/" branchbox.rb
-
-        # Update ARM URL and checksum
-        sed -i "s|url \"https://github.com/branchbox/branchbox/releases/download/v.*/branchbox-.*-aarch64-apple-darwin.tar.gz\"|url \"https://github.com/branchbox/branchbox/releases/download/v$VERSION/branchbox-$VERSION-aarch64-apple-darwin.tar.gz\"|" branchbox.rb
-        sed -i "/Hardware::CPU.arm?/,/sha256/ s/sha256 \".*\"/sha256 \"${{ steps.checksums.outputs.arm }}\"/" branchbox.rb
+        ruby <<'RUBY'
+          path = "homebrew-tap/Formula/branchbox.rb"
+          sha = {
+            "x86_64-apple-darwin"      => ENV.fetch("MACOS_INTEL"),
+            "aarch64-apple-darwin"     => ENV.fetch("MACOS_ARM"),
+            "x86_64-unknown-linux-gnu" => ENV.fetch("LINUX_INTEL"),
+            "aarch64-unknown-linux-gnu"=> ENV.fetch("LINUX_ARM"),
+          }
+          contents = File.read(path)
+          sha.each do |arch, checksum|
+            pattern = /(#{Regexp.escape(arch)}.*?\n\s*sha256 ")[0-9a-f]{64}"/
+            unless contents.sub!(pattern, "\\1#{checksum}\"")
+              abort "Failed to update checksum for #{arch} in #{path}"
+            end
+          end
+          File.write(path, contents)
+RUBY
 
     - name: Commit and push
       run: |
@@ -164,6 +196,8 @@ update-homebrew:
 
 **Required secret:**
 - `HOMEBREW_TAP_TOKEN`: GitHub Personal Access Token with `repo` scope for the tap repository
+
+> Keep the verification check plus the final `git diff --exit-code` and commit/push steps unchanged; with URLs deriving from `#{version}` the workflow now only edits the version and checksum lines.
 
 ### Testing
 

--- a/docs/features/completed/release-automation.md
+++ b/docs/features/completed/release-automation.md
@@ -306,11 +306,25 @@ class Branchbox < Formula
   version "1.0.0"
 
   on_macos do
-    if Hardware::CPU.intel?
-      url "https://github.com/branchbox/branchbox/releases/download/v1.0.0/branchbox-1.0.0-macos-x86_64.tar.gz"
+    on_intel do
+      url "https://github.com/branchbox/branchbox/releases/download/v#{version}/branchbox-#{version}-x86_64-apple-darwin.tar.gz"
       sha256 "..."
-    else
-      url "https://github.com/branchbox/branchbox/releases/download/v1.0.0/branchbox-1.0.0-macos-aarch64.tar.gz"
+    end
+
+    on_arm do
+      url "https://github.com/branchbox/branchbox/releases/download/v#{version}/branchbox-#{version}-aarch64-apple-darwin.tar.gz"
+      sha256 "..."
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "https://github.com/branchbox/branchbox/releases/download/v#{version}/branchbox-#{version}-x86_64-unknown-linux-gnu.tar.gz"
+      sha256 "..."
+    end
+
+    on_arm do
+      url "https://github.com/branchbox/branchbox/releases/download/v#{version}/branchbox-#{version}-aarch64-unknown-linux-gnu.tar.gz"
       sha256 "..."
     end
   end


### PR DESCRIPTION
## Summary
- update release workflow to bump version via sed and refresh sha256 hashes with a Ruby helper
- refresh Homebrew docs/runbooks to show on_macos/on_linux + on_intel/on_arm layout with URLs using #{version}
- note formula refactor already merged in branchbox/homebrew-tap (fix/ci-tests@41e2e44)

## Testing
- not run (workflow change only)
