### PR TITLE
fix(naming): auto-generate valid feature names from title-like inputs

### DIFF
--- a/core/src/workflows/feature.rs
+++ b/core/src/workflows/feature.rs
@@ -5008,36 +5008,25 @@ mod tests {
 
         let workflow = FeatureWorkflow::new(repo_path).unwrap();
 
-        // Valid name should be used directly
-        let request = StartRequest {
-            name: Some("oauth-integration".to_string()),
-            ..Default::default()
-        };
-        let result = workflow.resolve_work_feature(&request).unwrap();
-        assert_eq!(result, "oauth-integration");
+        // Table-driven test cases: (input, expected_output)
+        let test_cases = vec![
+            // Valid name should be used directly
+            ("oauth-integration", "oauth-integration"),
+            // Title-like input (uppercase, spaces, dots) should be auto-generated
+            ("Rails 8.1.2", "rails-812"),
+            // Another title-like input with uppercase
+            ("OAuth Integration", "oauth"),
+            // Input with spaces
+            ("fix bug 123", "fix-bug-123"),
+        ];
 
-        // Title-like input (uppercase, spaces, dots) should be auto-generated
-        let request = StartRequest {
-            name: Some("Rails 8.1.2".to_string()),
-            ..Default::default()
-        };
-        let result = workflow.resolve_work_feature(&request).unwrap();
-        assert_eq!(result, "rails-812");
-
-        // Another title-like input with uppercase
-        let request = StartRequest {
-            name: Some("OAuth Integration".to_string()),
-            ..Default::default()
-        };
-        let result = workflow.resolve_work_feature(&request).unwrap();
-        assert_eq!(result, "oauth");
-
-        // Input with spaces
-        let request = StartRequest {
-            name: Some("fix bug 123".to_string()),
-            ..Default::default()
-        };
-        let result = workflow.resolve_work_feature(&request).unwrap();
-        assert_eq!(result, "fix-bug-123");
+        for (input, expected) in test_cases {
+            let request = StartRequest {
+                name: Some(input.to_string()),
+                ..Default::default()
+            };
+            let result = workflow.resolve_work_feature(&request).unwrap();
+            assert_eq!(result, expected, "Failed on input: {}", input);
+        }
     }
 }


### PR DESCRIPTION
Previously, `branchbox feature start "Rails 8.1.2"` would fail with "Invalid feature name" because the input contained uppercase letters, spaces, and dots which don't match the DNS-safe regex `^[a-z0-9-]+$`.

Now, when a user provides an input that fails direct validation, the system automatically generates a valid name from it (treating it as a title) instead of rejecting it outright.

Examples:
- "Rails 8.1.2" → "rails-812"
- "OAuth Integration" → "oauth"
- "fix bug 123" → "fix-bug-123"

This improves UX by accepting human-readable titles as the positional argument, matching user expectations.