### PR TITLE
feat(cli): add prune workflow and bb alias packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,6 +209,7 @@ jobs:
 
           # Copy binary
           cp target/${{ matrix.target }}/release/branchbox "${ARCHIVE_NAME}/"
+          cp target/${{ matrix.target }}/release/branchbox "${ARCHIVE_NAME}/bb"
 
           # Copy documentation
           cp README.md LICENSE "${ARCHIVE_NAME}/"
@@ -229,6 +230,7 @@ jobs:
 
           # Copy binary
           Copy-Item target/${{ matrix.target }}/release/branchbox.exe "$ARCHIVE_NAME/"
+          Copy-Item target/${{ matrix.target }}/release/branchbox.exe "$ARCHIVE_NAME/bb.exe"
 
           # Copy documentation
           Copy-Item README.md,LICENSE "$ARCHIVE_NAME/"
@@ -465,6 +467,7 @@ jobs:
                 abort "Failed to update checksum for #{arch} in #{path}"
               end
             end
+            contents.gsub!(/^\s*bin\.install\s+"branchbox"(?:,\s*"bb")?\s*$/, '    bin.install "branchbox", "bb"')
             File.write(path, contents)
           RUBY
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.3] - 2026-03-05
+
+### Added
+- `branchbox prune` and `branchbox feature prune` to tear down all active feature worktrees in one command, with `--dry-run` and `--yes` support for safe automation.
+- Added a `features` alias for the `feature` command group so `branchbox features list` works.
+
+### Changed
+- Installer now creates a `bb` alias symlink to `branchbox` and warns when another `bb` command already exists in `PATH`.
+- Release packaging now ships `bb`/`bb.exe` alongside `branchbox`, and Homebrew formula automation updates install lines to include both binaries.
+
 ## [0.9.0] - 2026-02-27
 
 ### Added

--- a/cli/src/commands/feature.rs
+++ b/cli/src/commands/feature.rs
@@ -33,6 +33,9 @@ pub enum FeatureCommands {
 
     /// List known feature worktrees from the registry
     List(FeatureListArgs),
+
+    /// Tear down all active feature worktrees
+    Prune(FeaturePruneArgs),
 }
 
 #[derive(Args)]
@@ -151,11 +154,43 @@ pub struct FeatureListArgs {
     pub json: bool,
 }
 
+#[derive(Args)]
+pub struct FeaturePruneArgs {
+    /// Repository path (defaults to current directory)
+    #[arg(long)]
+    pub repo: Option<PathBuf>,
+
+    /// Show which features would be removed without applying teardown
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Skip confirmation prompt
+    #[arg(short = 'y', long)]
+    pub yes: bool,
+
+    /// Keep git branches after removing worktrees
+    #[arg(long)]
+    pub keep_branch: bool,
+
+    /// Delete git branches after removing worktrees
+    #[arg(long, conflicts_with = "keep_branch")]
+    pub delete_branch: bool,
+
+    /// Move specs to completed during teardown
+    #[arg(long)]
+    pub complete_spec: bool,
+
+    /// Emit verbose telemetry (e.g. Cloudflare operations)
+    #[arg(long)]
+    pub telemetry: bool,
+}
+
 pub fn execute(command: FeatureCommands) -> Result<()> {
     match command {
         FeatureCommands::Start(args) => run_start(args),
         FeatureCommands::Teardown(args) => run_teardown(args),
         FeatureCommands::List(args) => run_list(args),
+        FeatureCommands::Prune(args) => run_prune(args),
     }
 }
 
@@ -568,6 +603,113 @@ fn run_teardown(args: FeatureTeardownArgs) -> Result<()> {
     Ok(())
 }
 
+pub fn run_prune(args: FeaturePruneArgs) -> Result<()> {
+    let FeaturePruneArgs {
+        repo,
+        dry_run,
+        yes,
+        keep_branch,
+        delete_branch,
+        complete_spec,
+        telemetry,
+    } = args;
+
+    let repo_path = repo.unwrap_or_else(|| PathBuf::from("."));
+    let workflow = FeatureWorkflow::new(&repo_path)?;
+    let mut features = workflow.list_features()?;
+    features.retain(|feature| feature.status == FeatureStatus::Active);
+
+    if features.is_empty() {
+        println!("ℹ️  No active features to prune.");
+        return Ok(());
+    }
+
+    println!(
+        "🧹 Preparing to prune {} active feature worktree(s):",
+        features.len()
+    );
+    for feature in &features {
+        println!("  - {}", feature.work_feature);
+    }
+
+    if dry_run {
+        println!("ℹ️  Dry run only; no teardown executed.");
+        return Ok(());
+    }
+
+    if !yes {
+        if !Term::stdout().is_term() {
+            bail!(
+                "Refusing to prune in non-interactive mode without --yes. Rerun with --yes to confirm."
+            );
+        }
+
+        let proceed = Confirm::with_theme(&ColorfulTheme::default())
+            .with_prompt(format!(
+                "Tear down all {} active features now?",
+                features.len()
+            ))
+            .default(false)
+            .interact()?;
+        if !proceed {
+            bail!("Prune aborted.");
+        }
+    }
+
+    let config = BranchBoxConfig::load(workflow.repo_root()).unwrap_or_default();
+    let default_delete_branch = config.feature.teardown.delete_branch_by_default;
+    let should_delete_branch = if keep_branch {
+        false
+    } else if delete_branch {
+        true
+    } else {
+        default_delete_branch
+    };
+
+    let mut failed = Vec::new();
+    let total = features.len();
+
+    for feature in features {
+        println!();
+        println!("→ Pruning {}", feature.work_feature);
+
+        let request = TeardownRequest {
+            work_feature: feature.work_feature.clone(),
+            branch_prefix: derive_branch_prefix(&feature),
+            delete_branch: should_delete_branch,
+            force_delete_branch: should_delete_branch,
+            force_remove: true,
+            force_remove_modules: true,
+            complete_spec,
+            telemetry,
+        };
+
+        match workflow.teardown(request) {
+            Ok(summary) => print_teardown_summary(&summary),
+            Err(err) => {
+                eprintln!("✗ Failed to prune '{}': {}", feature.work_feature, err);
+                failed.push((feature.work_feature, err.to_string()));
+            }
+        }
+    }
+
+    println!();
+    if failed.is_empty() {
+        println!("✓ Pruned {} feature(s).", total);
+        return Ok(());
+    }
+
+    eprintln!(
+        "Completed prune with failures ({}/{} failed):",
+        failed.len(),
+        total
+    );
+    for (feature, reason) in failed {
+        eprintln!("  - {}: {}", feature, reason);
+    }
+    bail!("Prune completed with failures.")
+}
+
 fn handle_teardown_error(
     err: CoreError,
     workflow: &FeatureWorkflow,
@@ -623,6 +765,19 @@ fn build_branch_name(prefix: Option<&str>, work_feature: &str) -> String {
     } else {
         format!("{}/{}", prefix, work_feature)
     }
+}
+
+fn derive_branch_prefix(feature: &FeatureMetadata) -> Option<String> {
+    let suffix = format!("/{}", feature.work_feature);
+    if let Some(prefix) = feature.branch_name.strip_suffix(&suffix) {
+        return Some(prefix.to_string());
+    }
+
+    if feature.branch_name == feature.work_feature {
+        return Some(String::new());
+    }
+
+    None
 }
 
 fn local_branch_exists(repo_root: &Path, branch_name: &str) -> bool {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -6,7 +6,7 @@ use clap::{Parser, Subcommand};
 use commands::agent as agent_commands;
 use commands::agent::AgentCommands;
 use commands::devcontainer::{self, DevcontainerCommands};
-use commands::feature::{self, FeatureCommands};
+use commands::feature::{self, FeatureCommands, FeaturePruneArgs};
 use commands::init::{self, InitArgs};
 use commands::tunnel::{self, TunnelCommands};
 use std::path::PathBuf;
@@ -47,8 +47,11 @@ enum Commands {
     Name(NameCommands),
 
     /// Manage feature worktrees
-    #[command(subcommand)]
+    #[command(subcommand, alias = "features")]
     Feature(FeatureCommands),
+
+    /// Tear down all active feature worktrees
+    Prune(FeaturePruneArgs),
 
     /// Manage tunnels for existing features
     #[command(subcommand)]
@@ -126,6 +129,10 @@ fn main() -> Result<()> {
 
         Commands::Feature(feature_cmd) => {
             feature::execute(feature_cmd)?;
+        }
+
+        Commands::Prune(args) => {
+            feature::run_prune(args)?;
         }
 
         Commands::Tunnel(tunnel_cmd) => {

--- a/cli/tests/feature_commands.rs
+++ b/cli/tests/feature_commands.rs
@@ -506,3 +506,85 @@ fn feature_start_minimal_defers_default_agent_launch() {
         "Default coding agent launch skipped (devcontainer not provisioned yet). Run `branchbox devcontainer sync` first."
     ));
 }
+
+#[test]
+fn features_alias_accepts_plural_subcommand() {
+    let test_repo = init_test_repo();
+    let repo_path = test_repo.path();
+    let work_feature = "features-alias";
+    let worktree_path = test_repo.worktree_parent().join(work_feature);
+
+    branchbox_cmd!(repo_path)
+        .args(["feature", "start", work_feature])
+        .assert()
+        .success();
+
+    branchbox_cmd!(repo_path)
+        .args(["features", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(work_feature));
+
+    branchbox_cmd!(repo_path)
+        .args([
+            "feature",
+            "teardown",
+            work_feature,
+            "--delete-branch",
+            "--force",
+        ])
+        .assert()
+        .success();
+
+    assert!(
+        !worktree_path.exists(),
+        "expected worktree to be removed during teardown"
+    );
+}
+
+#[test]
+fn prune_command_tears_down_all_active_features() {
+    let test_repo = init_test_repo();
+    let repo_path = test_repo.path();
+    let feature_one = "prune-one";
+    let feature_two = "prune-two";
+    let worktree_one = test_repo.worktree_parent().join(feature_one);
+    let worktree_two = test_repo.worktree_parent().join(feature_two);
+
+    branchbox_cmd!(repo_path)
+        .args(["feature", "start", feature_one])
+        .assert()
+        .success();
+
+    branchbox_cmd!(repo_path)
+        .args(["feature", "start", feature_two])
+        .assert()
+        .success();
+
+    branchbox_cmd!(repo_path)
+        .args(["prune", "--yes"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Pruned 2 feature(s)."));
+
+    assert!(
+        !worktree_one.exists() && !worktree_two.exists(),
+        "expected both worktrees to be removed by prune"
+    );
+
+    let output = branchbox_cmd!(repo_path)
+        .args(["feature", "list", "--status", "active", "--json"])
+        .output()
+        .expect("feature list active --json");
+    assert!(
+        output.status.success(),
+        "expected feature list active --json to succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let payload: Value =
+        serde_json::from_slice(&output.stdout).expect("parse active feature list JSON");
+    let active = payload
+        .as_array()
+        .expect("active list should serialize as array");
+    assert!(active.is_empty(), "expected no active features after prune");
+}

--- a/install.sh
+++ b/install.sh
@@ -27,6 +27,10 @@ print_error() {
   echo -e "${RED}Error: $1${NC}" >&2
 }
 
+print_warning() {
+  echo -e "${YELLOW}Warning: $1${NC}" >&2
+}
+
 require_tools() {
   if ! has_command tar; then
     print_error "Required command not found: tar"
@@ -187,6 +191,40 @@ install_binary() {
   local source_binary="$1"
   local target_dir="$2"
 
+  warn_existing_bb_command() {
+    local alias_dir="$1"
+    local alias_path="$alias_dir/bb"
+    local existing_bb
+    existing_bb=$(command -v bb 2>/dev/null || true)
+
+    if [ -z "$existing_bb" ] || [ "$existing_bb" = "$alias_path" ]; then
+      return
+    fi
+
+    if [[ "$existing_bb" == */* ]]; then
+      print_warning "Detected existing 'bb' command at $existing_bb. BranchBox will install alias at $alias_path; PATH precedence decides which one runs."
+    else
+      print_warning "Detected existing shell entry for 'bb' ($existing_bb). BranchBox will still install alias at $alias_path."
+    fi
+  }
+
+  install_bb_alias() {
+    local alias_dir="$1"
+    local use_sudo="${2:-0}"
+    local alias_path="$alias_dir/bb"
+
+    if [ -e "$alias_path" ] && [ ! -L "$alias_path" ]; then
+      print_warning "$alias_path exists and is not a symlink; skipping bb alias creation"
+      return
+    fi
+
+    if [ "$use_sudo" = "1" ]; then
+      sudo ln -sfn "$BINARY_NAME" "$alias_path"
+    else
+      ln -sfn "$BINARY_NAME" "$alias_path"
+    fi
+  }
+
   if [ ! -f "$source_binary" ]; then
     print_error "Extracted binary not found: $source_binary"
     exit 1
@@ -196,6 +234,8 @@ install_binary() {
     echo "Installing to $target_dir (no sudo required)"
     mv "$source_binary" "$target_dir/$BINARY_NAME"
     chmod +x "$target_dir/$BINARY_NAME"
+    warn_existing_bb_command "$target_dir"
+    install_bb_alias "$target_dir"
     return
   fi
 
@@ -204,6 +244,8 @@ install_binary() {
     sudo mkdir -p "$target_dir"
     sudo mv "$source_binary" "$target_dir/$BINARY_NAME"
     sudo chmod +x "$target_dir/$BINARY_NAME"
+    warn_existing_bb_command "$target_dir"
+    install_bb_alias "$target_dir" "1"
     return
   fi
 
@@ -212,6 +254,8 @@ install_binary() {
   echo "Installing to $target_dir (user installation)"
   mv "$source_binary" "$target_dir/$BINARY_NAME"
   chmod +x "$target_dir/$BINARY_NAME"
+  warn_existing_bb_command "$target_dir"
+  install_bb_alias "$target_dir"
 
   case ":$PATH:" in
     *":$target_dir:"*)
@@ -328,6 +372,7 @@ main() {
   echo ""
   echo "Verify installation:"
   echo "  $BINARY_NAME --version"
+  echo "  bb --version"
   echo ""
   echo "Get started:"
   echo "  $BINARY_NAME --help"


### PR DESCRIPTION
## Summary
- add `branchbox prune` and `branchbox feature prune` to bulk-teardown active features
- add `features` alias for the `feature` command group
- package/install `bb` alias (`bb`/`bb.exe`) and add installer warnings for existing `bb` commands
- update `CHANGELOG.md` with 0.9.3 release notes

## Validation
- `cargo fmt --all`
- `SDKROOT="$(xcrun --sdk macosx --show-sdk-path)" cargo test -p branchbox-cli --test feature_commands features_alias_accepts_plural_subcommand -- --nocapture`
- `SDKROOT="$(xcrun --sdk macosx --show-sdk-path)" cargo test -p branchbox-cli --test feature_commands prune_command_tears_down_all_active_features -- --nocapture`
- `bash -n install.sh`
- local smoke on amidship: `branchbox prune --dry-run` then `branchbox prune --yes --delete-branch` (7 active features pruned)
