### PR TITLE
feat(cli): add --allow-container flag to feature teardown

### DIFF
--- a/cli/src/commands/feature.rs
+++ b/cli/src/commands/feature.rs
@@ -137,6 +137,10 @@ pub struct FeatureTeardownArgs {
     /// Emit verbose telemetry (e.g. Cloudflare operations)
     #[arg(long)]
     pub telemetry: bool,
+
+    /// Allow running feature teardown from inside a containerized environment
+    #[arg(long, alias = "no-host-check")]
+    pub allow_container: bool,
 }
 
 #[derive(Args)]
@@ -579,6 +583,7 @@ fn run_teardown(args: FeatureTeardownArgs) -> Result<()> {
         force_delete_branch,
         complete_spec,
         telemetry,
+        allow_container,
     } = args;
 
     let repo_path = repo.unwrap_or_else(|| PathBuf::from("."));
@@ -611,6 +616,7 @@ fn run_teardown(args: FeatureTeardownArgs) -> Result<()> {
         maybe_prompt_force_delete_branch(&repo_path, &config, &mut request)?;
     }
 
+    let _host_validation_override = HostValidationOverride::new(allow_container);
     let summary = match workflow.teardown(request.clone()) {
         Ok(summary) => summary,
         Err(err) => handle_teardown_error(err, &workflow, &mut request)?,


### PR DESCRIPTION
## Summary

- Adds `--allow-container` flag (with `--no-host-check` alias) to `branchbox feature teardown`, matching the existing flag on `feature start`
- When the flag is set, sets `BRANCHBOX_SKIP_HOST_VALIDATION=1` via the existing `HostValidationOverride` mechanism before calling `workflow.teardown()`
- Fixes the inability to clean up worktrees from within the same Docker container that created them

## Test plan

- [ ] `branchbox feature teardown <name> --allow-container` no longer errors with "Running in Docker container" inside a Docker environment
- [ ] `branchbox feature teardown <name> --no-host-check` works as an alias
- [ ] Without the flag, container validation still fires as before
- [ ] `branchbox feature teardown --help` shows the new flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)