### PR TITLE
feat(cli): prompt before moving uncommitted changes on feature start

### DIFF
--- a/agent/proto/agent.proto
+++ b/agent/proto/agent.proto
@@ -29,6 +29,7 @@ message StartRequest {
   repeated string skip_modules = 8;
   string mode = 9;
   string prompt_seed = 10;
+  bool move_changes = 11;
 }
 
 message StartResponse {

--- a/agent/src/grpc.rs
+++ b/agent/src/grpc.rs
@@ -90,6 +90,7 @@ impl FeatureService for GrpcFeatureService {
                 _ => StartMode::Full,
             },
             prompt_seed: optional_string(req.prompt_seed),
+            move_changes: req.move_changes,
         });
 
         let summary = ops::start_feature(&self.config, repo_path, start_req).map_err(to_status)?;

--- a/agent/src/ipc.rs
+++ b/agent/src/ipc.rs
@@ -144,6 +144,7 @@ async fn dispatch(
             skip_modules,
             minimal,
             prompt,
+            move_changes,
         } => {
             let request = ops::build_start_request(ops::StartRequestParams {
                 name,
@@ -159,6 +160,7 @@ async fn dispatch(
                     StartMode::Full
                 },
                 prompt_seed: prompt,
+                move_changes,
             });
 
             let summary = ops::start_feature(config, repo_path, request)?;
@@ -247,6 +249,8 @@ enum AgentRequest {
         minimal: bool,
         #[serde(default)]
         prompt: Option<String>,
+        #[serde(default)]
+        move_changes: bool,
     },
     TeardownFeature {
         #[serde(default)]

--- a/agent/src/ops.rs
+++ b/agent/src/ops.rs
@@ -67,6 +67,7 @@ pub struct StartRequestParams {
     pub skip_modules: Vec<String>,
     pub mode: StartMode,
     pub prompt_seed: Option<String>,
+    pub move_changes: bool,
 }
 
 pub fn build_start_request(params: StartRequestParams) -> StartRequest {
@@ -80,6 +81,7 @@ pub fn build_start_request(params: StartRequestParams) -> StartRequest {
         skip_modules: params.skip_modules,
         mode: params.mode,
         prompt_seed: params.prompt_seed,
+        move_changes: params.move_changes,
     }
 }
 

--- a/cli/src/commands/feature.rs
+++ b/cli/src/commands/feature.rs
@@ -271,7 +271,7 @@ fn run_start(args: FeatureStartArgs) -> Result<()> {
         true
     } else if no_move_changes || reuse {
         false
-    } else if !json && workflow.has_uncommitted_tracked_changes().unwrap_or(false) {
+    } else if !json && workflow.has_uncommitted_tracked_changes()? {
         Confirm::with_theme(&ColorfulTheme::default())
             .with_prompt("Move uncommitted tracked changes to the new feature worktree?")
             .default(false)

--- a/cli/src/commands/feature.rs
+++ b/cli/src/commands/feature.rs
@@ -273,15 +273,15 @@ fn run_start(args: FeatureStartArgs) -> Result<()> {
     } else if no_move_changes || reuse {
         false
     } else {
-        let is_interactive_session = !json && Term::stderr().is_term();
-        let has_dirty_changes =
-            is_interactive_session && workflow.has_uncommitted_tracked_changes()?;
-
-        has_dirty_changes
-            && Confirm::with_theme(&ColorfulTheme::default())
+        let is_interactive = !json && Term::stderr().is_term();
+        if is_interactive && workflow.has_uncommitted_tracked_changes()? {
+            Confirm::with_theme(&ColorfulTheme::default())
                 .with_prompt("Move uncommitted tracked changes to the new feature worktree?")
                 .default(false)
                 .interact_on(&Term::stderr())?
+        } else {
+            false
+        }
     };
 
     let request = StartRequest {

--- a/cli/src/commands/feature.rs
+++ b/cli/src/commands/feature.rs
@@ -99,6 +99,14 @@ pub struct FeatureStartArgs {
     /// Suppress summary output (text mode only)
     #[arg(long = "no-summary")]
     pub no_summary: bool,
+
+    /// Move uncommitted tracked changes to the new feature worktree
+    #[arg(long = "move-changes")]
+    pub move_changes: bool,
+
+    /// Keep uncommitted tracked changes in the current worktree (skip prompt)
+    #[arg(long = "no-move-changes", conflicts_with = "move_changes")]
+    pub no_move_changes: bool,
 }
 
 #[derive(Args)]
@@ -223,6 +231,8 @@ fn run_start(args: FeatureStartArgs) -> Result<()> {
         json,
         allow_container,
         no_summary,
+        move_changes,
+        no_move_changes,
     } = args;
 
     let mode = if minimal || fast {
@@ -255,6 +265,21 @@ fn run_start(args: FeatureStartArgs) -> Result<()> {
     let repo_path = repo.unwrap_or_else(|| PathBuf::from("."));
     let workflow = FeatureWorkflow::new(&repo_path)?;
 
+    // Determine whether to move uncommitted changes to the new worktree.
+    // Explicit flags take priority; otherwise prompt interactively (default: no).
+    let should_move_changes = if move_changes {
+        true
+    } else if no_move_changes || reuse {
+        false
+    } else if !json && workflow.has_uncommitted_tracked_changes().unwrap_or(false) {
+        Confirm::with_theme(&ColorfulTheme::default())
+            .with_prompt("Move uncommitted tracked changes to the new feature worktree?")
+            .default(false)
+            .interact_on(&Term::stderr())?
+    } else {
+        false
+    };
+
     let request = StartRequest {
         name,
         title,
@@ -265,6 +290,7 @@ fn run_start(args: FeatureStartArgs) -> Result<()> {
         skip_modules,
         mode,
         prompt_seed: prompt_seed.clone(),
+        move_changes: should_move_changes,
     };
 
     let _host_validation_override = HostValidationOverride::new(allow_container);

--- a/cli/src/commands/feature.rs
+++ b/cli/src/commands/feature.rs
@@ -267,17 +267,19 @@ fn run_start(args: FeatureStartArgs) -> Result<()> {
 
     // Determine whether to move uncommitted changes to the new worktree.
     // Explicit flags take priority; otherwise prompt interactively (default: no).
+    // Non-interactive sessions (no TTY, --json) silently default to false.
     let should_move_changes = if move_changes {
         true
     } else if no_move_changes || reuse {
         false
-    } else if !json && workflow.has_uncommitted_tracked_changes()? {
-        Confirm::with_theme(&ColorfulTheme::default())
-            .with_prompt("Move uncommitted tracked changes to the new feature worktree?")
-            .default(false)
-            .interact_on(&Term::stderr())?
     } else {
-        false
+        !json
+            && Term::stderr().is_term()
+            && workflow.has_uncommitted_tracked_changes()?
+            && Confirm::with_theme(&ColorfulTheme::default())
+                .with_prompt("Move uncommitted tracked changes to the new feature worktree?")
+                .default(false)
+                .interact_on(&Term::stderr())?
     };
 
     let request = StartRequest {

--- a/cli/src/commands/feature.rs
+++ b/cli/src/commands/feature.rs
@@ -273,9 +273,11 @@ fn run_start(args: FeatureStartArgs) -> Result<()> {
     } else if no_move_changes || reuse {
         false
     } else {
-        !json
-            && Term::stderr().is_term()
-            && workflow.has_uncommitted_tracked_changes()?
+        let is_interactive_session = !json && Term::stderr().is_term();
+        let has_dirty_changes =
+            is_interactive_session && workflow.has_uncommitted_tracked_changes()?;
+
+        has_dirty_changes
             && Confirm::with_theme(&ColorfulTheme::default())
                 .with_prompt("Move uncommitted tracked changes to the new feature worktree?")
                 .default(false)

--- a/core/src/workflows/feature.rs
+++ b/core/src/workflows/feature.rs
@@ -161,6 +161,9 @@ pub struct StartRequest {
     pub mode: StartMode,
     /// Optional prompt seed captured for agent/automation hand-off
     pub prompt_seed: Option<String>,
+    /// Move uncommitted tracked changes from the current worktree to the new feature worktree.
+    /// When false (the default), changes are left in the current worktree untouched.
+    pub move_changes: bool,
 }
 
 /// Result of running feature start workflow.
@@ -300,6 +303,28 @@ impl FeatureWorkflow {
         &self.repo_root
     }
 
+    /// Returns true when the main worktree has uncommitted changes to tracked files.
+    ///
+    /// Untracked files are intentionally ignored (they are never stashed).
+    pub fn has_uncommitted_tracked_changes(&self) -> Result<bool> {
+        let output = Command::new("git")
+            .args(["status", "--porcelain", "--untracked-files=no"])
+            .current_dir(&self.repo_root)
+            .output()
+            .map_err(|err| Error::git(format!("Failed to check git status: {}", err)))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(Error::git(format!(
+                "git status exited with error: {}",
+                stderr.trim()
+            )));
+        }
+
+        let changes = String::from_utf8_lossy(&output.stdout);
+        Ok(!changes.trim().is_empty())
+    }
+
     /// Start a feature, creating a new git worktree and running module setup.
     pub fn start(&self, request: StartRequest) -> Result<StartSummary> {
         self.ensure_host_environment()?;
@@ -390,7 +415,7 @@ impl FeatureWorkflow {
             warnings.push(format!("Git worktree path fix failed: {}", err));
         }
 
-        let stash_state = if !reuse_existing {
+        let stash_state = if !reuse_existing && request.move_changes {
             match self.capture_stash(&work_feature) {
                 Ok(state) => state,
                 Err(err) => {
@@ -4309,6 +4334,7 @@ mod tests {
         let summary = workflow
             .start(StartRequest {
                 name: Some("test-feature".to_string()),
+                move_changes: true,
                 ..StartRequest::default()
             })
             .unwrap();
@@ -4486,6 +4512,61 @@ mod tests {
             })
             .unwrap();
         assert!(teardown_summary.adapter_cleanup_warnings.is_empty());
+    }
+
+    #[test]
+    fn feature_start_leaves_tracked_changes_in_main_by_default() {
+        let temp = setup_test_repo();
+        let repo_path = temp.path();
+        fs::write(repo_path.join(".env"), "APP_URL=dev.example.com\n").unwrap();
+        copy_repo_devcontainer(repo_path);
+
+        std::env::set_var("BRANCHBOX_SKIP_HOST_VALIDATION", "1");
+        // Modify a tracked file
+        fs::write(repo_path.join("README.md"), "# Test Repo\nlocal change\n").unwrap();
+
+        let worktree_path = repo_path.parent().unwrap().join("no-move");
+        if worktree_path.exists() {
+            fs::remove_dir_all(&worktree_path).unwrap();
+        }
+
+        let workflow = FeatureWorkflow::new(repo_path).unwrap();
+        assert!(workflow.has_uncommitted_tracked_changes().unwrap());
+
+        let summary = workflow
+            .start(StartRequest {
+                name: Some("no-move".to_string()),
+                // move_changes defaults to false
+                ..StartRequest::default()
+            })
+            .unwrap();
+
+        // Tracked changes should stay in the main worktree, not be moved
+        let main_readme = fs::read_to_string(repo_path.join("README.md")).unwrap();
+        assert!(
+            main_readme.contains("local change"),
+            "tracked changes should remain in main worktree"
+        );
+
+        // Feature worktree gets the clean committed version
+        let worktree_readme = fs::read_to_string(summary.worktree_path.join("README.md")).unwrap();
+        assert_eq!(
+            worktree_readme, "# Test Repo\n",
+            "feature worktree should have committed version, not local changes"
+        );
+
+        // No stash should have been created
+        let stash_list = Command::new("git")
+            .args(["stash", "list"])
+            .current_dir(repo_path)
+            .output()
+            .unwrap();
+        assert!(
+            String::from_utf8_lossy(&stash_list.stdout)
+                .trim()
+                .is_empty(),
+            "no stash entries should exist"
+        );
     }
 
     #[test]

--- a/core/src/workflows/feature.rs
+++ b/core/src/workflows/feature.rs
@@ -1430,22 +1430,7 @@ impl FeatureWorkflow {
     fn capture_stash(&self, work_feature: &str) -> Result<StashState> {
         let stash_before = self.current_stash_oid()?;
 
-        let status = Command::new("git")
-            .args(["status", "--porcelain", "--untracked-files=no"])
-            .current_dir(&self.repo_root)
-            .output()
-            .map_err(|err| Error::git(format!("Failed to check git status: {}", err)))?;
-
-        if !status.status.success() {
-            let stderr = String::from_utf8_lossy(&status.stderr);
-            return Err(Error::git(format!(
-                "git status exited with error: {}",
-                stderr.trim()
-            )));
-        }
-
-        let changes = String::from_utf8_lossy(&status.stdout);
-        if changes.trim().is_empty() {
+        if !self.has_uncommitted_tracked_changes()? {
             return Ok(StashState::default());
         }
 


### PR DESCRIPTION
## Summary
- **Changed default behavior**: `branchbox feature start` no longer auto-moves uncommitted tracked changes to the new feature worktree
- **Added interactive prompt**: When the working tree is dirty and no explicit flag is provided, the CLI asks the user whether to move changes (default: No)
- **Added explicit flags**: `--move-changes` and `--no-move-changes` for scripting/automation, skipping the interactive prompt
- **Added `move_changes` to agent API surface**: Proto, gRPC, and IPC all support the new field (defaults to `false` for backward compatibility)

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] All 11 `feature_start*` unit tests pass (including new `feature_start_leaves_tracked_changes_in_main_by_default`)
- [x] Manual verification: `--no-move-changes` keeps dirty files in main, worktree gets committed version
- [x] Manual verification: `--move-changes` stashes and pops changes into the new worktree
- [x] `--help` shows both new flags with correct descriptions
- [ ] Verify interactive prompt appears on dirty tree without flags
- [ ] Verify prompt does NOT appear when `--json` is passed
- [ ] Verify prompt does NOT appear when tree is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)